### PR TITLE
Add links to descriptions of benchmarks

### DIFF
--- a/binarytrees/README.md
+++ b/binarytrees/README.md
@@ -1,4 +1,4 @@
-# Binary Trees Benchmark
+# [Binary Trees Benchmark](https://benchmarksgame-team.pages.debian.net/benchmarksgame/description/binarytrees.html#binarytrees)
 
 Focused on single threaded performance, so benchmarking to the
 idiomatic python and lua single-threaded solutions.  No tweaks,
@@ -13,4 +13,3 @@ $ lua binarytrees2.lua 21
 * binarytrees1.janet: **75s**
 * binarytrees2.py: **109s**
 * binarytrees2.lua: **218s**
-

--- a/fannkuch/README.md
+++ b/fannkuch/README.md
@@ -1,4 +1,4 @@
-# Fannkuch-redux benchmark
+# [Fannkuch-redux benchmark](https://benchmarksgame-team.pages.debian.net/benchmarksgame/description/fannkuchredux.html#fannkuchredux)
 
 ## Naive, single-threaded version
 
@@ -65,4 +65,3 @@ New version based on fannkuch4 (with rev table and all optimizations):
 fannkuch4-parallel.janet: **1.4s** real or **5.4s user**
 
 Equivalent to python.
-

--- a/knucleotide/README.md
+++ b/knucleotide/README.md
@@ -1,4 +1,4 @@
-# K-Nucleotide Benchmark
+# [K-Nucleotide Benchmark](https://benchmarksgame-team.pages.debian.net/benchmarksgame/description/knucleotide.html#knucleotide)
 
 Initially a single threaded version, for 25,000,000 size.
 
@@ -45,5 +45,4 @@ Originally, when I ran without gcsetinterval
 Points to some need to auto-adjust gc interval??
 As of [this commit](https://github.com/janet-lang/janet/commit/95c633914f0381c9800fedbcc0c47bf70d53f62a)
 on 6/27/20 auto-adjust of gc interval is now in the master branch.
-
 

--- a/nbody/README.md
+++ b/nbody/README.md
@@ -1,4 +1,4 @@
-# NBODY Benchmark
+# [NBODY Benchmark](https://benchmarksgame-team.pages.debian.net/benchmarksgame/description/nbody.html#nbody)
 
 Test with argument 5000000 (note that's 5M, not 50M as is typically
 used in nbody, because the algorithm is linear and I'm impatient.)
@@ -20,6 +20,3 @@ The idea is that indexing an array by an integer is faster than indexing
 a table by a keyword.  (Hash table lookup vs array lookup.)
 
 nbody2.janet **18.2s** competitive with lua, and beating python by 2x
-
-
-

--- a/pidigits/README.md
+++ b/pidigits/README.md
@@ -1,0 +1,1 @@
+# [Pi Digits](https://benchmarksgame-team.pages.debian.net/benchmarksgame/description/pidigits.html#pidigits)

--- a/regex-redux/README.md
+++ b/regex-redux/README.md
@@ -1,4 +1,4 @@
-# Regex Redux Benchmark
+# [Regex Redux Benchmark](https://benchmarksgame-team.pages.debian.net/benchmarksgame/description/regexredux.html#regexredux)
 
 Generate the input with
 
@@ -46,4 +46,3 @@ regexredux2.janet **15.3s**
 regexredux1.py   **11.3s**
 
 So it doubled Janet's speed on the benchmark.
-

--- a/reverse-complement/README.md
+++ b/reverse-complement/README.md
@@ -1,14 +1,13 @@
-# Reverse Complement
+# [Reverse Complement](https://benchmarksgame-team.pages.debian.net/benchmarksgame/description/revcomp.html#revcomp)
 
 A lot of byte shuffling and byte translation.
 
 Python does well at this because it includes a built-in string.translate
-which translates a set of charachters to some other set of characters
+which translates a set of characters to some other set of characters
 according to a translation table.  (In C obviously.)
 
-Neither Lua nor Janet have such.  Naiive version revcomp.janet runs
+Neither Lua nor Janet have such.  Naive version revcomp.janet runs
 70 seconds, vs 9 seconds for python.  By adding memoization the translated
 and reversed substrings of groups of characters, you can get it down to
 33 seconds, which is also by the way the same performance as the memoized
 lua version.
-


### PR DESCRIPTION
I thought it might be handy to have links to the original descriptions of the benchmarks.

WDYT?